### PR TITLE
Add HyperLogLog::merge

### DIFF
--- a/lib/Algorithm/HyperLogLog.pm
+++ b/lib/Algorithm/HyperLogLog.pm
@@ -124,6 +124,10 @@ Adds element to the cardinality estimator.
 
 Returns estimated cardinality value in floating point number.
 
+=head2 merge($other)
+
+Merges the estimate from 'other' into this object, returning the estimate of their union.
+
 =head2 register_size()
 
 Return number of register.(In the XS implementation, this equals size in bytes)

--- a/lib/Algorithm/HyperLogLog/PP.pm
+++ b/lib/Algorithm/HyperLogLog/PP.pm
@@ -112,6 +112,19 @@ sub estimate {
     return $estimate;
 }
 
+sub merge {
+    my ($self, $other) = @_;
+    my $m    = $self->{m};
+
+    die "hll size misatch" if $self->{m} != $other->{m};
+
+    for (my $i=0; $i<$m; $i++) {
+        if ($self->{registers}[$i] < $other->{registers}[$i]) {
+            $self->{registers}[$i] = $other->{registers}[$i];
+        }
+    }
+}
+
 sub XS {
     0;
 }

--- a/t/06_merge.t
+++ b/t/06_merge.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Fatal qw(exception lives_ok);
+use Algorithm::HyperLogLog;
+
+plan 'skip_all' => 'No XS' if !Algorithm::HyperLogLog->XS;
+
+my $hlla   = Algorithm::HyperLogLog->new(16);
+my $hllb   = Algorithm::HyperLogLog->new(16);
+
+$hlla->add($_) for 1..100_000;
+$hllb->add($_) for 100_000..200_000;
+
+$hlla->merge($hllb);
+
+ok( abs($hlla->estimate -200_000)/200_000 < 0.01);
+
+done_testing();
+
+__END__
+

--- a/t/06_merge.t
+++ b/t/06_merge.t
@@ -3,6 +3,7 @@ use warnings;
 use Test::More;
 use Test::Fatal qw(exception lives_ok);
 use Algorithm::HyperLogLog;
+use Algorithm::HyperLogLog::PP;
 
 plan 'skip_all' => 'No XS' if !Algorithm::HyperLogLog->XS;
 
@@ -15,6 +16,16 @@ $hllb->add($_) for 100_000..200_000;
 $hlla->merge($hllb);
 
 ok( abs($hlla->estimate -200_000)/200_000 < 0.01);
+
+my $hllppa   = Algorithm::HyperLogLog::PP->new(16);
+my $hllppb   = Algorithm::HyperLogLog::PP->new(16);
+
+$hllppa->add($_) for 1..100_000;
+$hllppb->add($_) for 100_000..200_000;
+
+$hllppa->merge($hllppb);
+
+ok( abs($hllppa->estimate -200_000)/200_000 < 0.01);
 
 done_testing();
 

--- a/xs/hyperloglog.xs
+++ b/xs/hyperloglog.xs
@@ -209,6 +209,29 @@ CODE:
 OUTPUT:
     RETVAL
 
+
+# Merge two HLLs
+double
+merge(HLL self, HLL other)
+CODE:
+{
+    uint32_t m = self->m;
+    uint32_t i = 0;
+
+    if (m != other->m) {
+        croak("hll size mismatch: %d != %d\n", m, other->m);
+    }
+
+    for (i = 0; i < m; i++) {
+        if (self->registers[i] < other->registers[i]) {
+            self->registers[i] = other->registers[i];
+        }
+    }
+    XSRETURN_UNDEF;
+}
+OUTPUT:
+    RETVAL
+
 # Destructor
 void
 DESTROY(HLL self)


### PR DESCRIPTION
This allows merging to two hyperloglog objects to estimate the
cardinality of their union.
